### PR TITLE
Handle configs that are functions

### DIFF
--- a/nsm/scripts/copy-nextjs-config.js
+++ b/nsm/scripts/copy-nextjs-config.js
@@ -9,6 +9,11 @@ async function copyNextjsConfig() {
   let nextConfig = {}
   if (existsSync(nextConfigPath)) {
     nextConfig = require(nextConfigPath)
+
+    if (typeof nextConfig === "function") {
+      nextConfig = await nextConfig()
+    }
+
     if (typeof nextConfig.rewrites === "function") {
       nextConfig.rewrites = await nextConfig.rewrites()
     }


### PR DESCRIPTION
I'm not sure why this suddenly broke (and seemingly only broke for me) since Seam Connect has been exporting a config function for a long time.

Without this change, nsm was building/copying `next.config.js` as `export default undefined`.