### PR TITLE
feat: Await server start or throw

### DIFF
--- a/nsm/index.ts
+++ b/nsm/index.ts
@@ -106,7 +106,15 @@ export const runServer = async ({ port, middlewares = [] }: {port: number, middl
       false
     )
   })
-  server.listen(port)
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', (err) => {
+      if (err) reject(err)
+    })
+    server.listen(port, () => {
+      resolve()
+    })
+  })
   return server
 }
 

--- a/tests/wait-for-server.test.ts
+++ b/tests/wait-for-server.test.ts
@@ -1,0 +1,12 @@
+import test from "ava"
+import getPort from "get-port"
+import { getSampleProject } from "./fixtures/get-sample-project"
+
+test("wait for server to start or throw", async (t) => {
+  const { nsmIndex } = await getSampleProject()
+
+  const port = await getPort()
+  const server = await nsmIndex({ port })
+  await t.throwsAsync(() => nsmIndex({ port }), { code: 'EADDRINUSE' })
+  server.close()
+})


### PR DESCRIPTION
This converts the `server.listen` step to a promise and awaits the result. This could be considered a breaking change, a feature, or a bug fix, depending on what the expected behavior was. 

Previously, if the server failed to start, the error would be uncaught (no callback passed) but the caller would not know until they tried to interact with the server. Now the caller will get an error when the server tries to start and fails. This feels like it should be the expected behavior, however if the caller relies on the async startup behavior, then this can be considered a breaking change.