### PR TITLE
fix: Allow Skipping Next Build, Add Verbose Mode

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -6,7 +6,8 @@ const prettier = require("prettier")
 const fs = require("fs/promises")
 const findUp = require("find-up")
 
-const build = async ({ dir }) => {
+const build = async ({ dir, verbose, skipNextBuild }) => {
+  const logv = verbose ? console.log : () => {}
   const packageDirWithNext =
     (await findUp(
       async (directory) => {
@@ -20,6 +21,7 @@ const build = async ({ dir }) => {
         cwd: dir,
       }
     )) || dir
+  logv({ packageDirWithNext })
   try {
     require.resolve(`${packageDirWithNext}/node_modules/next`)
   } catch (e) {
@@ -28,17 +30,20 @@ const build = async ({ dir }) => {
     )
   }
 
+
   const nsmDir = `${dir}/.nsm`
 
+  logv("removing and copying nsm... ", { nsmDir })
   await rimraf(nsmDir)
   await copyDir(path.resolve(__dirname, "../nsm"), nsmDir)
 
-  const nextBuild =
-    require(`${packageDirWithNext}/node_modules/next/dist/build/index`).default
+  logv({ skipNextBuild })
+  if (!skipNextBuild) {
+    const nextBuild =
+      require(`${packageDirWithNext}/node_modules/next/dist/build/index`).default
 
-  await nextBuild(dir, null, false, false, false)
-
-  const nextDir = `${dir}/.next`
+    await nextBuild(dir, null, false, false, false)
+  }
 
   // Run the generateRoutes command
   console.log("generating routes...")

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,12 +6,22 @@ const { build } = require("./build")
 async function main() {
   const argv = yargs(hideBin(process.argv))
     .command("build", "build .next and .nsm", (yargs) => {})
+    .option("verbose", {
+      alias: "v",
+      type: "boolean",
+      description: "Show verbose output",
+    })
+    .option("skip-next-build", {
+      type: "boolean",
+      default: false,
+      description: "Skip the next build step",
+    })
     .help().argv
 
   const cmd = argv._[0]
   switch (cmd) {
     case "build": {
-      await build({ dir: path.resolve(".") })
+      await build({ dir: path.resolve("."), verbose: argv.verbose, skipNextBuild: argv["skip-next-build"] })
       break
     }
   }

--- a/nsm/get-server-fixture.ts
+++ b/nsm/get-server-fixture.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*
 
 Modeled after nextjs-ava-fixture, this utility function will provide you a
@@ -8,7 +9,6 @@ server for your test suite to use.
 import { ExecutionContext } from "ava"
 import axios from "axios"
 import getPort from "get-port"
-import { wrappers } from "nextjs-middleware-wrappers"
 import { runServer } from "./"
 
 interface Options {
@@ -20,7 +20,10 @@ async function getServerFixture(t: ExecutionContext, options: Options = {}) {
 
   if (!options.middlewares) options.middlewares = []
 
-  const server = await runServer({ port, middlewares: options.middlewares as any })
+  const server = await runServer({
+    port,
+    middlewares: options.middlewares as any,
+  })
 
   t.teardown(() => {
     server.close()

--- a/tests/fixtures/get-sample-project.ts
+++ b/tests/fixtures/get-sample-project.ts
@@ -8,7 +8,9 @@ export const getSampleProject = async () => {
   await execa("yarn", [], { cwd: projectPath })
 
   await build({
-    dir: projectPath
+    dir: projectPath,
+    verbose: false,
+    skipNextBuild: false,
   })
 
   const nsmIndex = require(path.resolve(
@@ -29,6 +31,6 @@ export const getSampleProject = async () => {
 
   return {
     nsmIndex: nsmIndex.default,
-    getServerFixture: getServerFixture.default
+    getServerFixture: getServerFixture.default,
   }
 }


### PR DESCRIPTION
Lots of issues with nsm in monorepos, this helps solve one of them involving nsm infinitely loading because next can't finish compiling