### PR TITLE
fix: Use consistent type imports

### DIFF
--- a/nsm/index.ts
+++ b/nsm/index.ts
@@ -10,7 +10,7 @@ import resolveRewrites from "./nextjs-middleware/resolve-rewrites"
 import nextConfig from "./next.config"
 import { removePathTrailingSlash } from "./nextjs-middleware/normalize-trailing-slash"
 import { getRouteRegex } from "./route-matcher/route-regex"
-import { NextApiHandler } from "./types/nextjs"
+import { type NextApiHandler } from "./types/nextjs"
 
 const debug = Debug("nsm")
 

--- a/nsm/nextjs-middleware/api-utils.ts
+++ b/nsm/nextjs-middleware/api-utils.ts
@@ -1,9 +1,9 @@
 // Modified version of: https://github.com/vercel/next.js/blob/e8408c70863b6bcd05437ff92a19194788716722/packages/next/server/api-utils.ts
-import { IncomingMessage, ServerResponse } from "http"
+import { type IncomingMessage, type ServerResponse } from "http"
 import { Stream } from "stream"
 import getRawBody from "raw-body"
 import { parse } from "content-type"
-import { NextApiRequest, NextApiResponse } from "../types/nextjs"
+import { type NextApiRequest, type NextApiResponse } from "../types/nextjs"
 import { serialize } from "cookie"
 
 export type NextApiRequestCookies = { [key: string]: string }

--- a/nsm/nextjs-middleware/querystring.ts
+++ b/nsm/nextjs-middleware/querystring.ts
@@ -1,5 +1,5 @@
 // https://github.com/vercel/next.js/blob/136b75439612bf6f2f0cd3fd0d8226fdaa8c0f95/packages/next/shared/lib/router/utils/querystring.ts
-import { ParsedUrlQuery } from "querystring"
+import { type ParsedUrlQuery } from "querystring"
 
 export function searchParamsToUrlQuery(
   searchParams: URLSearchParams

--- a/nsm/nextjs-middleware/resolve-rewrites.ts
+++ b/nsm/nextjs-middleware/resolve-rewrites.ts
@@ -1,4 +1,4 @@
-import { ParsedUrlQuery } from "querystring"
+import { type ParsedUrlQuery } from "querystring"
 import pathMatch from "./path-match"
 import { matchHas, prepareDestination } from "./prepare-destination"
 import { removePathTrailingSlash } from "./normalize-trailing-slash"

--- a/nsm/types/nextjs.ts
+++ b/nsm/types/nextjs.ts
@@ -1,5 +1,5 @@
 // https://github.com/vercel/next.js/blob/bb6d4d71fd419b64e2a3ce4d3496f2150f9ff86b/packages/next/shared/lib/utils.ts
-import { ServerResponse, IncomingMessage } from "http"
+import { type ServerResponse, type IncomingMessage } from "http"
 
 type Send<T> = (body: T) => void
 


### PR DESCRIPTION
Without this, stricter typescript configs from consumers will refuse to compile when importing from `.nsm`.