### PR TITLE
feat: Set @ts-nocheck for all files under nsm

### DIFF
--- a/nsm/generated_routes.ts
+++ b/nsm/generated_routes.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // This file is replaced by scripts/generate-routes.js during the build
 // process
 export default {}

--- a/nsm/index.ts
+++ b/nsm/index.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import routes from "./generated_routes"
 import { Server } from "http"
 import { apiResolver } from "./nextjs-middleware/api-utils"

--- a/nsm/nextjs-middleware/api-utils.ts
+++ b/nsm/nextjs-middleware/api-utils.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // Modified version of: https://github.com/vercel/next.js/blob/e8408c70863b6bcd05437ff92a19194788716722/packages/next/server/api-utils.ts
 import { IncomingMessage, ServerResponse } from "http"
 import { Stream } from "stream"

--- a/nsm/nextjs-middleware/normalize-locale-path.ts
+++ b/nsm/nextjs-middleware/normalize-locale-path.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // https://github.com/vercel/next.js/blob/eb0bd63af48ea9bec85670ad1bcbc455c5f879ec/packages/next/shared/lib/i18n/normalize-locale-path.ts
 export interface PathLocale {
   detectedLocale?: string

--- a/nsm/nextjs-middleware/normalize-trailing-slash.ts
+++ b/nsm/nextjs-middleware/normalize-trailing-slash.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /**
  * Removes the trailing slash of a path if there is one. Preserves the root path `/`.
  */

--- a/nsm/nextjs-middleware/parse-relative-url.ts
+++ b/nsm/nextjs-middleware/parse-relative-url.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { searchParamsToUrlQuery } from "./querystring"
 
 /**

--- a/nsm/nextjs-middleware/parse-url.ts
+++ b/nsm/nextjs-middleware/parse-url.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import type { ParsedUrlQuery } from "querystring"
 import { searchParamsToUrlQuery } from "./querystring"
 import { parseRelativeUrl } from "./parse-relative-url"

--- a/nsm/nextjs-middleware/path-match.ts
+++ b/nsm/nextjs-middleware/path-match.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as pathToRegexp from "path-to-regexp"
 
 export { pathToRegexp }

--- a/nsm/nextjs-middleware/prepare-destination.ts
+++ b/nsm/nextjs-middleware/prepare-destination.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import type { IncomingMessage } from "http"
 import type { RouteHas } from "../types/nextjs"
 import { compile, pathToRegexp } from "path-to-regexp"

--- a/nsm/nextjs-middleware/querystring.ts
+++ b/nsm/nextjs-middleware/querystring.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // https://github.com/vercel/next.js/blob/136b75439612bf6f2f0cd3fd0d8226fdaa8c0f95/packages/next/shared/lib/router/utils/querystring.ts
 import { ParsedUrlQuery } from "querystring"
 

--- a/nsm/nextjs-middleware/resolve-rewrites.ts
+++ b/nsm/nextjs-middleware/resolve-rewrites.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { ParsedUrlQuery } from "querystring"
 import pathMatch from "./path-match"
 import { matchHas, prepareDestination } from "./prepare-destination"

--- a/nsm/route-matcher/get-route-matcher-func.ts
+++ b/nsm/route-matcher/get-route-matcher-func.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // https://github.com/vercel/next.js/blob/402f0360cece821b9e0017f6ecb499d129993600/packages/next/shared/lib/router/utils/route-matcher.ts
 import { getRouteRegex } from "./route-regex"
 

--- a/nsm/route-matcher/index.ts
+++ b/nsm/route-matcher/index.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getRouteRegex } from "./route-regex"
 import { getRouteMatcherFunc } from "./get-route-matcher-func"
 

--- a/nsm/route-matcher/route-regex.ts
+++ b/nsm/route-matcher/route-regex.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // https://github.com/vercel/next.js/blob/e65c56e7e6c16c3c971984ce7acd161bca6b9c2f/packages/next/shared/lib/router/utils/route-regex.ts
 
 interface Group {

--- a/nsm/scripts/generate-routes.js
+++ b/nsm/scripts/generate-routes.js
@@ -46,7 +46,8 @@ async function generateRoutes() {
   }
 
   const routesFile = prettier.format(
-    `import serveStatic from "./serve-static"
+    `// @ts-nocheck
+    import serveStatic from "./serve-static"
     export default {
   ${Object.entries(pagesManifest)
     .map(([route, fp]) => {

--- a/nsm/serve-static.ts
+++ b/nsm/serve-static.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import mime from "mime-types"
 import { NextApiHandler } from "./types/nextjs"
 

--- a/nsm/types/nextjs.ts
+++ b/nsm/types/nextjs.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 // https://github.com/vercel/next.js/blob/bb6d4d71fd419b64e2a3ce4d3496f2150f9ff86b/packages/next/shared/lib/utils.ts
 import { ServerResponse, IncomingMessage } from "http"
 


### PR DESCRIPTION
A key behavior of this module is generating non-bundled TS code into the callers `.nsm` directory. This code is then consumed by the dependent via their TypeScript compiler. If stricter compiler options are used by the consumer, their type checks will fail.

Alternatively, the files could all be updated to pass the strictest typescript config, however it's unclear if differing consumer typescript configs could still conflict and fail to compile.

We can get the widest compatibility by simply disabling the typescript checks. This is more consistent with how things in `node_modules` are treated. Perhaps it would be better to compile `.nsm` to plain JavaScript and emit types instead, but that would be a more significant change.

One open question I still have: does adding ts-nocheck change any types that a consumer might export? Or rephrased, was forcing the consumer to typecheck these generated files serving any useful purpose?   