### PR TITLE
Export named functions

### DIFF
--- a/nsm/get-server-fixture.ts
+++ b/nsm/get-server-fixture.ts
@@ -15,7 +15,7 @@ interface Options {
   middlewares?: Array<Function>
 }
 
-async function getServerFixture(t: ExecutionContext, options: Options = {}) {
+export async function getServerFixture(t: ExecutionContext, options: Options = {}) {
   const port = await getPort()
 
   if (!options.middlewares) options.middlewares = []

--- a/nsm/serve-static.ts
+++ b/nsm/serve-static.ts
@@ -2,7 +2,7 @@
 import mime from "mime-types"
 import { NextApiHandler } from "./types/nextjs"
 
-const serveStatic = (ext: string, content: any) => ((req, res) => {
+export const serveStatic = (ext: string, content: any) => ((req, res) => {
   const contentType = mime.lookup(ext)
   if (contentType) {
     res.setHeader("Content-Type", contentType)


### PR DESCRIPTION
Helps ergonomics between esm and commonjs. Otherwise esm consumers must use `.default` to access the default export. 