### PR TITLE
Fix absolute path being used when bundling

### DIFF
--- a/nsm/index.ts
+++ b/nsm/index.ts
@@ -108,6 +108,8 @@ export const runServer = async ({
     const apiHandler =
       typeof pathOrFunction === "string"
         ? require(pathOrFunction)
+        : "module" in pathOrFunction
+        ? pathOrFunction.module
         : pathOrFunction
 
     if (apiHandler.config?.runtime === "edge") {
@@ -120,7 +122,7 @@ export const runServer = async ({
             import {NextRequest} from "next/dist/server/web/spec-extension/request"
             import {NextFetchEvent} from "next/dist/server/web/spec-extension/fetch-event"
 
-            import handler from "${pathOrFunction}"
+            import handler from "${pathOrFunction.fsPath}"
 
             if (typeof handler !== 'function') {
               throw new Error('The Edge Function "pages${page}" must export a \`default\` function');

--- a/nsm/route-matcher/index.ts
+++ b/nsm/route-matcher/index.ts
@@ -21,7 +21,13 @@ export default (routeMapping: any) => {
 
   // TODO sort routes to fix precedence
 
-  return (incomingPath: string) => {
+  return (
+    incomingPath: string,
+  ): {
+    pathOrFunction: string | { fsPath: string; module: any }
+    match: any
+    fsPath: string
+  } | null => {
     for (const { pathOrFunction, matcherFunc, fsPath } of routes) {
       const match = matcherFunc(incomingPath)
       if (match) {

--- a/nsm/scripts/generate-routes.js
+++ b/nsm/scripts/generate-routes.js
@@ -69,6 +69,9 @@ function getStaticRoutesFiles({ nextless, staticFiles }) {
      )}`
 }
 
+const isApiRoute = (filepath) =>
+  filepath.startsWith("pages/api") || filepath.startsWith("src/pages/api")
+
 async function generateRouteFile({
   pagesDirRelativePath,
   pagesManifest,
@@ -91,15 +94,15 @@ async function generateRouteFile({
         return true
       }
 
-      if (!onlyApiFiles && !fp.startsWith("pages/api")) {
+      if (!onlyApiFiles && !isApiRoute(fp)) {
         throw new Error(
           `At the moment, only API routes are supported. Found: ${fp}`,
         )
       }
 
       if (
-        (onlyApiFiles && !fp.startsWith("pages/api")) ||
-        (!nextless && onlyApiFiles && !fp.startsWith("pages/api"))
+        (onlyApiFiles && !isApiRoute(fp)) ||
+        (!nextless && onlyApiFiles && !isApiRoute(fp))
       ) {
         return false
       }
@@ -110,7 +113,7 @@ async function generateRouteFile({
       const fpNoExt = fp.split(".").slice(0, -1).join(".")
       const fpExt = fpNoExt.split(".").slice(-1)[0]
 
-      if (fp.startsWith("pages/api")) {
+      if (isApiRoute(fp)) {
         return `"${route}": {module: require("${pagesDirRelativePath}/${fpNoExt}"), fsPath: "${pagesDirRelativePath}/${fpNoExt}"}`
       } else {
         return `"${route}": serveStatic("${fpExt}", require("./generated_static/server/${fp}.ts").default)`

--- a/nsm/scripts/generate-routes.js
+++ b/nsm/scripts/generate-routes.js
@@ -111,14 +111,7 @@ async function generateRouteFile({
       const fpExt = fpNoExt.split(".").slice(-1)[0]
 
       if (fp.startsWith("pages/api")) {
-        const absolutePath = path.join(
-          __dirname,
-          "../",
-          pagesDirRelativePath,
-          fpNoExt,
-        )
-
-        return `"${route}": "${absolutePath}"`
+        return `"${route}": {module: require("${pagesDirRelativePath}/${fpNoExt}"), fsPath: "${pagesDirRelativePath}/${fpNoExt}"}`
       } else {
         return `"${route}": serveStatic("${fpExt}", require("./generated_static/server/${fp}.ts").default)`
       }


### PR DESCRIPTION
https://github.com/seamapi/nextjs-server-modules/pull/63 introduced a bug where the bundle included the absolute path to files on whatever machine built the package. 